### PR TITLE
Extends oracle expiration to 24h

### DIFF
--- a/omnia/config/relay.conf
+++ b/omnia/config/relay.conf
@@ -80,55 +80,55 @@
     "BTC/USD": {
       "msgExpiration": 1800,
       "oracle": "0xe0F30cb149fAADC7247E953746Be9BbBB6B5751f",
-      "oracleExpiration": 15500,
+      "oracleExpiration": 86400,
       "oracleSpread": 2
     },
     "ETH/BTC": {
       "msgExpiration": 1800,
       "oracle": "0x81A679f98b63B3dDf2F17CB5619f4d6775b3c5ED",
-      "oracleExpiration": 15500,
+      "oracleExpiration": 86400,
       "oracleSpread": 2
     },
     "ETH/USD": {
       "msgExpiration": 1800,
       "oracle": "0x64DE91F5A373Cd4c28de3600cB34C7C6cE410C85",
-      "oracleExpiration": 15500,
+      "oracleExpiration": 86400,
       "oracleSpread": 2
     },
     "LINK/USD": {
       "msgExpiration": 1800,
       "oracle": "0xbAd4212d73561B240f10C56F27e6D9608963f17b",
-      "oracleExpiration": 15500,
+      "oracleExpiration": 86400,
       "oracleSpread": 4
     },
     "MANA/USD": {
       "msgExpiration": 1800,
       "oracle": "0x681c4F8f69cF68852BAd092086ffEaB31F5B812c",
-      "oracleExpiration": 15500,
+      "oracleExpiration": 86400,
       "oracleSpread": 4
     },
     "MATIC/USD": {
       "msgExpiration": 1800,
       "oracle": "0xfe1e93840D286C83cF7401cB021B94b5bc1763d2",
-      "oracleExpiration": 15500,
+      "oracleExpiration": 86400,
       "oracleSpread": 4
     },
     "UNI/USD": {
       "msgExpiration": 1800,
       "oracle": "0x52f761908cc27b4d77ad7a329463cf08baf62153",
-      "oracleExpiration": 15500,
+      "oracleExpiration": 86400,
       "oracleSpread": 4
     },
     "WSTETH/USD": {
       "msgExpiration": 1800,
       "oracle": "0x2F73b6567B866302e132273f67661fB89b5a66F2",
-      "oracleExpiration": 15500,
+      "oracleExpiration": 86400,
       "oracleSpread": 2
     },
     "YFI/USD": {
       "msgExpiration": 1800,
       "oracle": "0x89AC26C0aFCB28EC55B6CD2F6b7DAD867Fa24639",
-      "oracleExpiration": 15500,
+      "oracleExpiration": 86400,
       "oracleSpread": 4
     }
   }


### PR DESCRIPTION
## Merge Criteria

- [ ] run `nix-env -i -f https://github.com/makerdao/oracles-v2/tarball/stable` and then run `nix-env -i -f .`
- [ ] install `omnia` as a *feed* on a clean VPS using `install-omnia`
  - [ ] make sure `systemctl status omnia` is `active` and hasn't exited
  - [ ] check that output from `journalctl -e -u omnia` looks reasonable
  - [ ] make sure `systemctl status ssb-server` is `active` and hasn't exited
  - [ ] check that output from `journalctl -e -u ssb-server` looks reasonable
  - [ ] reboot VPS and make sure services auto-start
- [ ] install `omnia` as a *relay* on a clean VPS using `install-omnia`
  - [ ] make sure `systemctl status omnia` is `active` and hasn't exited
  - [ ] check that output from `journalctl -e -u omnia` looks reasonable
  - [ ] make sure `systemctl status ssb-server` is `active` and hasn't exited
  - [ ] check that output from `journalctl -e -u ssb-server` looks reasonable
  - [ ] reboot VPS and make sure services auto-start
