### PR TITLE
Revert "Push ORACLE_VERSION to omnia during build"

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -43,14 +43,7 @@ in rec {
 
   stark-cli = pkgs.callPackage ../starkware { };
 
-  omnia = pkgs.callPackage sources.omnia {
-    inherit ssb-server stark-cli oracle-suite setzer;
-    oracleVersion = pkgs.lib.fileContents ../version;
-  };
-  #  omnia = pkgs.callPackage ../../omnia {
-  #    inherit ssb-server stark-cli oracle-suite setzer;
-  #    oracleVersion = pkgs.lib.fileContents ../version;
-  #  };
+  omnia = pkgs.callPackage sources.omnia { inherit ssb-server stark-cli oracle-suite setzer; };
 
   install-omnia = pkgs.callPackage ../systemd { inherit omnia ssb-server oracle-suite; };
 }


### PR DESCRIPTION
Reverts chronicleprotocol/oracles#15

breaks installation
```
error: anonymous function at /nix/store/ryqnsfp68x036z0c8k7iq7wfm9pd4vhn-omnia-src/default.nix:1:1 called with unexpected argument 'oracleVersion', at /nix/store/0bgkyaxvp925w7k81p1jjgai75kls3h7-nixpkgs-src/lib/customisation.nix:69:16
(use '--show-trace' to show detailed location information)
```